### PR TITLE
hotfix empty results when captcha is found on page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -56,6 +56,11 @@ Apify.main(async () => {
         handlePageTimeoutSecs: 60,
         requestTimeoutSecs: 180,
         handlePageFunction: async ({ request, response, body, $ }) => {
+            // TODO: Remove this when providers are properly filtering this again
+            if ($('#recaptcha').length) {
+                throw new Error('Captcha found, retrying...');
+            }
+
             request.userData.finishedAt = new Date();
 
             const nonzeroPage = request.userData.page + 1; // Display same page numbers as Google, i.e. 1, 2, 3..


### PR DESCRIPTION
Sometimes the result returned by the proxy is a captcha, until they fix this at their end, we can just retry the request when it's present on the page