### PR TITLE
[FIX] Google search returns only few results #637

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "main.js",
 	"dependencies": {
 		"apify": "^2.1",
+		"chrono-node": "2.3.5",
 		"query-string": "^6.11.1",
 		"underscore": "^1.9.2"
 	},

--- a/src/extractors/desktop.js
+++ b/src/extractors/desktop.js
@@ -1,4 +1,3 @@
-
 const { ensureItsAbsoluteUrl } = require('./ensure_absolute_url');
 const { extractPeopleAlsoAsk, extractDescriptionAndDate } = require('./extractor_tools');
 
@@ -16,13 +15,15 @@ exports.extractOrganicResults = ($) => {
         const siteLinksSel2021January = 'table';
 
         if ($(el).parent().parent().siblings(siteLinksSel2021January).length > 0) {
-            $(el).parent().parent().siblings(siteLinksSel2021January).find('td .sld').each((i, siteLinkEl) => {
-                siteLinks.push({
-                    title: $(siteLinkEl).find('a').text(),
-                    url: $(siteLinkEl).find('a').attr('href'),
-                    ...extractDescriptionAndDate($(siteLinkEl).find('.s').text()),
+            $(el).parent().parent().siblings(siteLinksSel2021January)
+                .find('td .sld')
+                .each((i, siteLinkEl) => {
+                    siteLinks.push({
+                        title: $(siteLinkEl).find('a').text(),
+                        url: $(siteLinkEl).find('a').attr('href'),
+                        ...extractDescriptionAndDate($(siteLinkEl).find('.s').text()),
+                    });
                 });
-            });
         } else if ($(el).find(siteLinksSel2020).length > 0) {
             $(el).find(siteLinksSel2020).each((i, siteLinkEl) => {
                 siteLinks.push({
@@ -32,7 +33,7 @@ exports.extractOrganicResults = ($) => {
                     ...extractDescriptionAndDate($(siteLinkEl).parent('div').parent('h3').parent('div')
                         .find('> div')
                         .toArray()
-                        .map(d => $(d).text())
+                        .map((d) => $(d).text())
                         .join(' ') || null),
                 });
             });
@@ -77,7 +78,7 @@ exports.extractOrganicResults = ($) => {
         };
 
         return searchResult;
-    }
+    };
 
     // TODO: If you figure out how to reasonably generalize this, you get a medal
     const resultSelectorOld = '.g .rc';
@@ -85,12 +86,12 @@ exports.extractOrganicResults = ($) => {
     const resultSelector2021January = '.g .tF2Cxc>.yuRUbf';
     const resultSelector2022January = '.g [data-header-feature="0"]';
 
-    let searchResults = []
+    let searchResults = [];
     if ($(`${resultSelector2022January}`).length > 0) {
         searchResults = [...$(`${resultSelector2022January}`)].reduce((organicResultsSels, organicResultSel) => {
             // We  fetch the list of sub organic results contained in one organic result section
             // It may be hijacking the siteLinks and flattening them into the organicResultsSels
-            const subOrganicResultsSels = $(organicResultSel).map((i, organicItem) => parseResult($(organicItem).parent())).toArray()
+            const subOrganicResultsSels = $(organicResultSel).map((i, organicItem) => parseResult($(organicItem).parent())).toArray();
             organicResultsSels.push(...subOrganicResultsSels);
             return organicResultsSels;
         }, []);
@@ -130,7 +131,7 @@ exports.extractPaidResults = ($) => {
                     ...extractDescriptionAndDate($(siteLinkEl).parent('div').parent('h3').parent('div')
                         .find('> div')
                         .toArray()
-                        .map(d => $(d).text())
+                        .map((d) => $(d).text())
                         .join(' ') || null),
                 });
             });

--- a/src/extractors/extractor_tools.js
+++ b/src/extractors/extractor_tools.js
@@ -1,4 +1,24 @@
 const cheerio = require("cheerio");
+const chrono = require('chrono-node');
+
+exports.extractDescriptionAndDate = (text) => {
+    let date;
+    let description = (text || '').trim();
+    // Parse all dates in the description
+    const parsedDates = chrono.parse(description);
+    if (parsedDates.length > 0) {
+        // we may use this parsed description date and add it to the output object
+        const [descriptionDate] = parsedDates;
+        // If first date is at the beginning of the description, we remove it
+        if (descriptionDate.index === 0) {
+            date = descriptionDate.date().toISOString(); // we use the refDate to avoid the timezone offset
+            description = description.slice(descriptionDate.text.length).trim();
+            // Removes leading non-word characters
+            description = description.replace(/^\W+/g, '');
+        }
+    }
+    return { description, date };
+};
 
 exports.extractPeopleAlsoAsk = ($) => {
     const peopleAlsoAsk = [];

--- a/src/extractors/mobile.js
+++ b/src/extractors/mobile.js
@@ -1,5 +1,5 @@
 const { ensureItsAbsoluteUrl } = require('./ensure_absolute_url');
-const { extractPeopleAlsoAsk } = require('./extractor_tools');
+const { extractPeopleAlsoAsk, extractDescriptionAndDate } = require('./extractor_tools');
 
 /**
  * there are 3 possible mobile layouts, we need to find out
@@ -99,7 +99,7 @@ exports.extractOrganicResults = ($, hostname) => {
                 title: $el.find('a div[role="heading"]').text(),
                 url: $el.find('a').first().attr('href'),
                 displayedUrl: $el.find('span.qzEoUe').first().text(),
-                description: $el.find('div.yDYNvb').text(),
+                ...extractDescriptionAndDate($el.find('div.yDYNvb').text()),
                 emphasizedKeywords: $el.find('div.yDYNvb').find('em, b').map((i, el) => $(el).text().trim()).toArray(),
                 siteLinks,
                 productInfo,
@@ -143,7 +143,7 @@ exports.extractOrganicResults = ($, hostname) => {
                     title: $el.find('a > h3').eq(0).text().trim(),
                     url: getUrlFromParameter($el.find('a').first().attr('href'), hostname),
                     displayedUrl: $el.find('a > div').eq(0).text().trim(),
-                    description: $description.text().replace(/ · /g, '').trim(),
+                    ...extractDescriptionAndDate($description.text().replace(/ · /g, '').trim()),
                     emphasizedKeywords: $description.find('em, b').map((i, el) => $(el).text().trim()).toArray(),
                     siteLinks,
                 });
@@ -192,7 +192,7 @@ exports.extractOrganicResults = ($, hostname) => {
                         .eq(1)
                         .text()
                         .trim(),
-                    description: $el.find('table span').first().text().trim(),
+                    ...extractDescriptionAndDate($el.find('table span').first().text().trim()),
                     emphasizedKeywords: $el.find('table span').first().find('em, b').map((i, el) => $(el).text().trim()).toArray(),
                     siteLinks,
                 });
@@ -235,7 +235,7 @@ exports.extractPaidResults = ($) => {
                 url: $url.attr('href'),
                 displayedUrl: $url.next('div').find('> span').eq(1).text()
                     || $url.find('> div').eq(0).find('> div > span').eq(1).text(),
-                description: $url.parent().next('div').find('span').eq(0).text(),
+                ...extractDescriptionAndDate($url.parent().next('div').find('span').eq(0).text()),
                 emphasizedKeywords: $url.parent().next('div').find('span').eq(0).find('em, b')
                     .map((i, el) => $(el).text().trim()).toArray(),
                 siteLinks,
@@ -270,7 +270,7 @@ exports.extractPaidResults = ($) => {
                     title: $el.find('div[role="heading"]').text().trim(),
                     url: $el.find('a').attr('href'),
                     displayedUrl: $el.find('a span.Zu0yb.UGIkD.qzEoUe').text().trim(),
-                    description: $el.find('div.w1C3Le div.MUxGbd.yDYNvb.lEBKkf').text().trim(),
+                    ...extractDescriptionAndDate($el.find('div.w1C3Le div.MUxGbd.yDYNvb.lEBKkf').text().trim()),
                     emphasizedKeywords: $el.find('div.w1C3Le div.MUxGbd.yDYNvb.lEBKkf').find('em, b')
                         .map((i, el) => $(el).text().trim()).toArray(),
                     siteLinks,
@@ -299,8 +299,8 @@ exports.extractPaidResults = ($) => {
                     title: $heading.text(),
                     url: $el.find('a[href*="aclk"]').attr('href'),
                     displayedUrl: $heading.next('div').find('> span > span').text(),
-                    description: $el.find('> div > div > div > span').text(),
-                    emphasizedKeywords:  $el.find('> div > div > div > span').find('em, b')
+                    ...extractDescriptionAndDate($el.find('> div > div > div > span').text()),
+                    emphasizedKeywords: $el.find('> div > div > div > span').find('em, b')
                         .map((i, el) => $(el).text().trim()).toArray(),
                     siteLinks,
                 });

--- a/src/extractors/mobile.js
+++ b/src/extractors/mobile.js
@@ -94,7 +94,6 @@ exports.extractOrganicResults = ($, hostname) => {
                 productInfo.price = Number(productInfoPriceText.replace(/[^0-9.]/g, ''));
             }
 
-
             searchResults.push({
                 title: $el.find('a div[role="heading"]').text(),
                 url: $el.find('a').first().attr('href'),
@@ -193,7 +192,8 @@ exports.extractOrganicResults = ($, hostname) => {
                         .text()
                         .trim(),
                     ...extractDescriptionAndDate($el.find('table span').first().text().trim()),
-                    emphasizedKeywords: $el.find('table span').first().find('em, b').map((i, el) => $(el).text().trim()).toArray(),
+                    emphasizedKeywords: $el.find('table span').first().find('em, b').map((i, el) => $(el).text().trim())
+                        .toArray(),
                     siteLinks,
                 });
             });
@@ -231,13 +231,17 @@ exports.extractPaidResults = ($) => {
             const $url = $heading.parent('a');
 
             ads.push({
-                title: $heading.find('span').length ? $heading.find('span').toArray().map(s => $(s).text()).join(' ') : $heading.text(),
+                title: $heading.find('span').length ? $heading.find('span').toArray().map((s) => $(s).text()).join(' ') : $heading.text(),
                 url: $url.attr('href'),
                 displayedUrl: $url.next('div').find('> span').eq(1).text()
-                    || $url.find('> div').eq(0).find('> div > span').eq(1).text(),
-                ...extractDescriptionAndDate($url.parent().next('div').find('span').eq(0).text()),
-                emphasizedKeywords: $url.parent().next('div').find('span').eq(0).find('em, b')
-                    .map((i, el) => $(el).text().trim()).toArray(),
+                    || $url.find('> div').eq(0).find('> div > span').eq(1)
+                        .text(),
+                ...extractDescriptionAndDate($url.parent().next('div').find('span').eq(0)
+                    .text()),
+                emphasizedKeywords: $url.parent().next('div').find('span').eq(0)
+                    .find('em, b')
+                    .map((i, el) => $(el).text().trim())
+                    .toArray(),
                 siteLinks,
             });
         });
@@ -254,8 +258,8 @@ exports.extractPaidResults = ($) => {
                         title: $(el).text().trim(),
                         url: $(el).attr('href'),
                         description: null,
-                    })
-                })
+                    });
+                });
 
                 // This is for horizontal site links
                 $el.find('g-scrolling-carousel a').each((i, el) => {
@@ -263,8 +267,8 @@ exports.extractPaidResults = ($) => {
                         title: $(el).text().trim(),
                         url: $(el).attr('href'),
                         description: null,
-                    })
-                })
+                    });
+                });
 
                 ads.push({
                     title: $el.find('div[role="heading"]').text().trim(),
@@ -275,7 +279,7 @@ exports.extractPaidResults = ($) => {
                         .map((i, el) => $(el).text().trim()).toArray(),
                     siteLinks,
                 });
-            })
+            });
         }
     }
 


### PR DESCRIPTION
More than a fix this is a feature proposition as well. As I was fixing the description I realized that some results had dates (relative or absolute) as part of the beginning of the description with a non standard format and nodes organization. This date indicates the last editing date of the page.

## Tasks done

1. Added [chrono-node](https://github.com/wanasit/chrono) lib. It can parse free text into date segments. I've extracted the date at the beginning when present thanks to it.

2. Generalized the description/date extraction to descriptions in all layouts (mobile & desktop). I've only changed/fixed the desktop selectors as it was the original issue.

## Next
I've tested it via the console with the default inputs with a max 10 pages per search input. So far I do get all the organic results as well as their description and date (when there is one available).

Open for review & feel free to run it too.
