### PR TITLE
Speed up short scrapes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,10 @@ Apify.main(async () => {
         requestList,
         requestQueue,
         proxyConfiguration,
-        maxConcurrency,
+        autoscaledPoolOptions: {
+            maxConcurrency,
+            desiredConcurrency: 10
+        },
         preNavigationHooks: [async ({ request }) => {
             const parsedUrl = url.parse(request.url, true);
             request.userData.startedAt = new Date();


### PR DESCRIPTION
Setting the desired concurrency to 10 will launch up to 10 requests ASAP, instead of waiting for the pool to scale up. This will have significant impact on speed of crawls with batches of size 5-500.